### PR TITLE
Minor update to install on a brand new server

### DIFF
--- a/hashids.sql
+++ b/hashids.sql
@@ -401,7 +401,7 @@ begin
 end;
 $$ language plpgsql;
 
-drop function hashids.decode_hex;
+drop function if exists hashids.decode_hex;
 
 create or replace function hashids.decode_hex(
   id varchar,


### PR DESCRIPTION
When you run the script for the first time on a PostgreSQL server that does not have the functions, it fails when trying to drop the `hashids.decode_hex` function.